### PR TITLE
Bugfix: addIdFilter does not work on category collection when flat catalog is enabled

### DIFF
--- a/app/code/community/Netzarbeiter/GroupsCatalog2/Model/Catalog/Resource/Category/Flat/Collection.php
+++ b/app/code/community/Netzarbeiter/GroupsCatalog2/Model/Catalog/Resource/Category/Flat/Collection.php
@@ -1,0 +1,39 @@
+<?php
+
+class Netzarbeiter_GroupsCatalog2_Model_Catalog_Resource_Category_Flat_Collection
+    extends Mage_Catalog_Model_Resource_Category_Flat_Collection
+{
+
+    /**
+     * Add filter by entity id(s).
+     *
+     * Original function had only 'entity_id' in addFieldToFilter(), which
+     * is an ambigious name since the Observer joins the index table.
+     * (copied from CE 1.7.0.2)
+     *
+     * @param mixed $categoryIds
+     * @return Mage_Catalog_Model_Resource_Category_Flat_Collection
+     */
+    public function addIdFilter($categoryIds)
+    {
+        if (is_array($categoryIds)) {
+            if (empty($categoryIds)) {
+                $condition = '';
+            } else {
+                $condition = array('in' => $categoryIds);
+            }
+        } elseif (is_numeric($categoryIds)) {
+            $condition = $categoryIds;
+        } elseif (is_string($categoryIds)) {
+            $ids = explode(',', $categoryIds);
+            if (empty($ids)) {
+                $condition = $categoryIds;
+            } else {
+                $condition = array('in' => $ids);
+            }
+        }
+        $this->addFieldToFilter('main_table.entity_id', $condition);
+        return $this;
+    }
+
+}

--- a/app/code/community/Netzarbeiter/GroupsCatalog2/etc/config.xml
+++ b/app/code/community/Netzarbeiter/GroupsCatalog2/etc/config.xml
@@ -49,6 +49,7 @@
 			<catalog_resource>
 				<rewrite>
 					<category_flat>Netzarbeiter_GroupsCatalog2_Model_Catalog_Resource_Category_Flat</category_flat>
+                    <category_flat_collection>Netzarbeiter_GroupsCatalog2_Model_Catalog_Resource_Category_Flat_Collection</category_flat_collection>
 				</rewrite>
 			</catalog_resource>
 			<!-- rewrite the catalogseach fulltext collection to add the filter to the getSelectCountSql() method -->


### PR DESCRIPTION
See it in action on the RSS page when _Top Level Category RSS Feed_ is enabled **and** _Flat Catalog Category_ is enabled. 

`Mage_Rss_Block_List::CategoriesRssFeed()` calls `addIdFilter($nodeIds)`. `Mage_Catalog_Model_Resource_Category_Flat_Collection::addIdFilter()` in turn calls `$this->addFieldToFilter('entity_id', $condition);`, but `entity_id` has become ambigious because of the join you add on the collection in the observer.

The only I could think of to fix this, was to extend `Mage_Catalog_Model_Resource_Category_Flat_Collection` and change the column reference to `main_table.entity_id`.

Actually, this is a bugfix for the core class which should have used `main_table.entity_id` and not for your extension :)
